### PR TITLE
Quick improvements for filterDescendants

### DIFF
--- a/src/models/block.js
+++ b/src/models/block.js
@@ -109,9 +109,7 @@ class Block extends new Record(DEFAULTS) {
    */
 
   get text() {
-    return this.nodes
-      .map(node => node.text)
-      .join('')
+    return this.getText()
   }
 
 }

--- a/src/models/document.js
+++ b/src/models/document.js
@@ -83,9 +83,7 @@ class Document extends new Record(DEFAULTS) {
    */
 
   get text() {
-    return this.nodes
-      .map(node => node.text)
-      .join('')
+    return this.getText()
   }
 
 }

--- a/src/models/inline.js
+++ b/src/models/inline.js
@@ -109,9 +109,7 @@ class Inline extends new Record(DEFAULTS) {
    */
 
   get text() {
-    return this.nodes
-      .map(node => node.text)
-      .join('')
+    return this.getText()
   }
 
 }

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -170,7 +170,9 @@ const Node = {
 
   forEachDescendant(iterator) {
     return this.nodes.forEach((child, i, nodes) => {
-      iterator(child, i, nodes)
+      if (iterator(child, i, nodes) === false) {
+        return false
+      }
       if (child.kind != 'text') child.forEachDescendant(iterator)
     })
   },

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -159,18 +159,16 @@ const Node = {
    */
 
   findDescendantDeep(iterator) {
-    let descendantFound = null
+    let found
 
-    const found = this.nodes.find(node => {
-      if (node.kind != 'text') {
-        descendantFound = node.findDescendantDeep(iterator)
-        return descendantFound || iterator(node)
+    this.forEachDescendant(node => {
+      if (iterator(node)) {
+        found = node
+        return false
       }
-
-      return iterator(node) ? node : null
     })
 
-    return descendantFound || found
+    return found
   },
 
   /**

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -29,7 +29,7 @@ const Node = {
   getKeys() {
     const keys = []
 
-    this.filterDescendants(desc => {
+    this.forEachDescendant(desc => {
       keys.push(desc.key)
     })
 

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -937,7 +937,11 @@ const Node = {
    */
 
   getTexts() {
-    return this.filterDescendants(node => node.kind == 'text')
+    return this.nodes.reduce((texts, node) => {
+      return node.kind == 'text'
+        ? texts.push(node)
+        : texts.concat(node.getTexts())
+    }, List())
   },
 
   /**

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -163,6 +163,19 @@ const Node = {
   },
 
   /**
+   * Recursively iterate over all descendant nodes with `iterator`.
+   *
+   * @param {Function} iterator
+   */
+
+  forEachDescendant(iterator) {
+    return this.nodes.forEach((child, i, nodes) => {
+      iterator(child, i, nodes)
+      if (child.kind != 'text') child.forEachDescendant(iterator)
+    })
+  },
+
+  /**
    * Recursively filter all descendant nodes with `iterator`.
    *
    * @param {Function} iterator
@@ -170,11 +183,13 @@ const Node = {
    */
 
   filterDescendants(iterator) {
-    return this.nodes.reduce((matches, child, i, nodes) => {
-      if (iterator(child, i, nodes)) matches = matches.push(child)
-      if (child.kind != 'text') matches = matches.concat(child.filterDescendants(iterator))
-      return matches
-    }, Block.createList())
+    const matches = []
+
+    this.forEachDescendant((child, i, nodes) => {
+      if (iterator(child, i, nodes)) matches.push(child)
+    })
+
+    return List(matches)
   },
 
   /**
@@ -920,11 +935,7 @@ const Node = {
    */
 
   getTexts() {
-    return this.nodes.reduce((texts, node) => {
-      return node.kind == 'text'
-        ? texts.push(node)
-        : texts.concat(node.getTexts())
-    }, Block.createList())
+    return this.filterDescendants(node => node.kind == 'text')
   },
 
   /**

--- a/src/models/node.js
+++ b/src/models/node.js
@@ -37,6 +37,17 @@ const Node = {
   },
 
   /**
+   * Get the concatenated text `string` of all child nodes.
+   *
+   * @return {String} text
+   */
+
+  getText() {
+    return this.nodes
+      .reduce((result, node) => result + node.text, '')
+  },
+
+  /**
    * Assert that a node has a child by `key` and return it.
    *
    * @param {String or Node} key
@@ -1315,6 +1326,7 @@ const Node = {
  */
 
 memoize(Node, [
+  'getText',
   'getAncestors',
   'getBlocks',
   'getBlocksAtRange',

--- a/src/models/text.js
+++ b/src/models/text.js
@@ -112,8 +112,7 @@ class Text extends new Record(DEFAULTS) {
 
   get text() {
     return this.characters
-      .map(char => char.text)
-      .join('')
+      .reduce((result, char) => result + char.text, '')
   }
 
   /**


### PR DESCRIPTION
Avoid doing concat on immutable `List` and instead build an array then return it.

It also adds a `forEachDescendant` when we just want to iterate over nodes without creating a return list.