### PR TITLE
Global memoization control, faster benchmark script

### DIFF
--- a/perf/benchmarks/memoize-util/index.js
+++ b/perf/benchmarks/memoize-util/index.js
@@ -2,8 +2,6 @@ const { default: memoize } = require('../../../lib/utils/memoize')
 
 module.exports = {
   setup(state) {
-    window.__NO_MEMOIZE = false
-
     let obj = {
       fibonacci(n = 20) {
         if (n === 0 || n === 1) {
@@ -20,11 +18,5 @@ module.exports = {
 
   run(obj) {
     obj.fibonacci()
-    // Clear cache for next runs
-    delete obj.__cache
-  },
-
-  teardown() {
-    window.__NO_MEMOIZE = true
   }
 }

--- a/perf/benchmarks/memoize-util/index.js
+++ b/perf/benchmarks/memoize-util/index.js
@@ -2,6 +2,8 @@ const { default: memoize } = require('../../../lib/utils/memoize')
 
 module.exports = {
   setup(state) {
+    window.__NO_MEMOIZE = false
+
     let obj = {
       fibonacci(n = 20) {
         if (n === 0 || n === 1) {
@@ -18,5 +20,11 @@ module.exports = {
 
   run(obj) {
     obj.fibonacci()
+    // Clear cache for next runs
+    delete obj.__cache
+  },
+
+  teardown() {
+    window.__NO_MEMOIZE = true
   }
 }

--- a/perf/index.js
+++ b/perf/index.js
@@ -110,6 +110,10 @@ function runBenchmarks() {
       fn() {
         scope.benchmark.run(state) // eslint-disable-line no-undef
         // Next call will use another State instance
+      },
+
+      onComplete() {
+        global.getScope().benchmark.teardown()
       }
     }))
   }

--- a/perf/index.js
+++ b/perf/index.js
@@ -22,6 +22,8 @@ const readMetadata = require('read-metadata')
 const { Raw } = require('..')
 const { resolve } = require('path')
 
+window.__NO_MEMOIZE = true
+
 const DEFAULT_BENCHMARK = {
   setup(state) { return state },
   run(state) {}
@@ -95,27 +97,19 @@ function runBenchmarks() {
         // memoization between calls to `fn`
         const scope = global.getScope()
 
-        let states = []
-        let numberOfExecution = this.count
-        while (numberOfExecution--) {
-          states.push(
-            // Each benchmark is given the chance to do its own setup
-            scope.benchmark.setup(
-              scope.Raw.deserialize(scope.input, { terse: true })
-            )
-          )
-        }
-
-        let stateIndex = 0
+        const state =
+              // Each benchmark is given the chance to do its own setup
+              scope.benchmark.setup(
+                scope.Raw.deserialize(scope.input, { terse: true })
+              )
       },
 
       // Because of the way BenchmarkJS compiles the functions,
       // the variables declared in `setup` are visible to `fn`
 
       fn() {
-        scope.benchmark.run(states[stateIndex]) // eslint-disable-line no-undef
+        scope.benchmark.run(state) // eslint-disable-line no-undef
         // Next call will use another State instance
-        stateIndex++ // eslint-disable-line no-undef
       }
     }))
   }

--- a/perf/index.js
+++ b/perf/index.js
@@ -111,7 +111,8 @@ function runBenchmarks() {
       },
 
       onComplete() {
-        global.getScope().benchmark.teardown()
+        const teardown = global.getScope().benchmark.teardown
+        if (teardown) teardown()
       }
     }))
   }

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -42,6 +42,10 @@ function memoize(object, properties) {
     }
 
     object[property] = function (...args) {
+      if (window.__NO_MEMOIZE) {
+        return original.apply(this, args)
+      }
+
       const keys = [property, ...args]
       this.__cache = this.__cache || new Map()
 


### PR DESCRIPTION
This PR adds two DEV utility functions to the `utils/memoize` module, to allow to clear previous memoization caches, or to disable memoization globally.

These functions are then used for running benchmark, which removes complex code that used to create many different Slate state instances to bypass memoization.
Now, the benchmarks script are faster, meaning less time is spent setting up the benchmarks.