### PR TITLE
Fix replaceNodeByKey failing to normalize a node's parent

### DIFF
--- a/packages/slate/src/changes/by-key.js
+++ b/packages/slate/src/changes/by-key.js
@@ -423,7 +423,7 @@ Changes.replaceNodeByKey = (change, key, newNode, options = {}) => {
   const parent = document.getParent(key)
   const index = parent.nodes.indexOf(node)
   change.removeNodeByKey(key, { normalize: false })
-  change.insertNodeByKey(parent.key, index, newNode, options)
+  change.insertNodeByKey(parent.key, index, newNode, { normalize: false })
   if (normalize) {
     change.normalizeNodeByKey(parent.key)
   }

--- a/packages/slate/test/changes/by-key/replace-node-by-key/no-intermediate-normalization.js
+++ b/packages/slate/test/changes/by-key/replace-node-by-key/no-intermediate-normalization.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+import h from '../../../helpers/h'
+
+/*
+ * This test makes sure there are no intermediate normalization
+ * when calling replaceNodeByKey which calls removeNodeByKey and insertNodeByKey successively.
+ */
+
+export default function(change) {
+  // Replacing <hashtag> by an empty text means the <link> is now empty
+  // and empty inlines are removed, according to Slate's core schema.
+  // If an intermediate normalization were to happen, the final normalization
+  // would fail to find the node's parent and thus throw because that parent
+  // has already been removed before (due to the intermediate normalization).
+  change.replaceNodeByKey('a', { object: 'text', text: '' })
+}
+
+export const input = (
+  <value>
+    <document>
+      <paragraph>
+        <link>
+          <hashtag key="a">lorem</hashtag>
+        </link>
+      </paragraph>
+    </document>
+  </value>
+)
+
+export const output = (
+  <value>
+    <document>
+      <paragraph />
+    </document>
+  </value>
+)


### PR DESCRIPTION
This PR fixes a number of bugs that have been reported on GitBook. They're usually reported as:

```
Error: Could not find a node with key "ee5e1e66a0bc4a59b00b5c37c102f3b3".
    at Document.assertNode (/user_code/node_modules/slate/src/models/node.js:257:13)
    at Changes$6.normalizeNodeByKey (/user_code/node_modules/slate/src/changes/with-schema.js:41:25)
    at Change.call (/user_code/node_modules/slate/lib/slate.js:12903:10)
    at Change.(anonymous function) [as normalizeNodeByKey] (/user_code/node_modules/slate/src/models/change.js:220:5)
    at Changes$2.replaceNodeByKey (/user_code/node_modules/slate/src/changes/by-key.js:428:12)
...
```

The bug is due to the `replaceNodeByKey` normalizing twice but with the parent being removed in the first normalization.