### PR TITLE
Replace core schema with model-level-validations

### DIFF
--- a/packages/slate/src/constants/model-types.ts
+++ b/packages/slate/src/constants/model-types.ts
@@ -4,6 +4,7 @@
 
 const MODEL_TYPES = {
     BLOCK: '@@__SLATE_BLOCK__@@',
+    CONTAINER: '@@__SLATE_CONTAINER__@@',
     CHANGE: '@@__SLATE_CHANGE__@@',
     CHARACTER: '@@__SLATE_CHARACTER__@@',
     DOCUMENT: '@@__SLATE_DOCUMENT__@@',

--- a/packages/slate/src/index.ts
+++ b/packages/slate/src/index.ts
@@ -3,6 +3,7 @@ import { resetMemoization, useMemoization } from 'immutablejs-record-memoize';
 import Changes from './changes';
 import Block from './models/block';
 import Change from './models/change';
+import Container from './models/Container';
 import Data from './models/data';
 import Document from './models/document';
 import History from './models/history';
@@ -37,6 +38,7 @@ export {
     Document,
     History,
     Inline,
+    Container,
     Leaf,
     Mark,
     Node,

--- a/packages/slate/src/models/inline.ts
+++ b/packages/slate/src/models/inline.ts
@@ -4,7 +4,11 @@ import isPlainObject from 'is-plain-object';
 import MODEL_TYPES, { isType } from '../constants/model-types';
 import generateKey from '../utils/generate-key';
 import { DataJSON } from './data';
-import NodeFactory, { memoizeMethods, NodeDefaultProps } from './node-factory';
+import NodeFactory, {
+    ChildNode,
+    memoizeMethods,
+    NodeDefaultProps
+} from './node-factory';
 import Text, { TextCreateProps, TextJSON } from './text';
 
 interface InlineProperties {
@@ -183,6 +187,13 @@ class Inline extends NodeFactory<InlineProperties>({
         }
 
         return object;
+    }
+
+    /*
+     * Validate that a child is valid in this node.
+     */
+    public validateChild(child: ChildNode): boolean {
+        return child.isText() || child.isInline();
     }
 }
 

--- a/packages/slate/src/models/node-factory.ts
+++ b/packages/slate/src/models/node-factory.ts
@@ -9,6 +9,7 @@ import Text from './text';
 
 // Types only
 import Block from './block';
+import Container from './container';
 import Document from './document';
 import Inline from './inline';
 
@@ -39,7 +40,7 @@ function NodeFactory<Properties extends object>(defaultProps: Properties) {
         public readonly data: DataMap;
         public readonly nodes: List<ChildNode>;
 
-        public readonly object: 'inline' | 'block' | 'document';
+        public readonly object: 'inline' | 'block' | 'document' | 'container';
 
         public isText(): this is Text {
             return false;
@@ -55,6 +56,17 @@ function NodeFactory<Properties extends object>(defaultProps: Properties) {
 
         public isDocument(): this is Document {
             return this.object === 'document';
+        }
+
+        public isContainer(): this is Container {
+            return this.object === 'container';
+        }
+
+        /*
+         * Validate that a child is valid in this node.
+         */
+        public validateChild(child: ChildNode): boolean {
+            return true;
         }
 
         /*
@@ -1324,7 +1336,7 @@ function NodeFactory<Properties extends object>(defaultProps: Properties) {
         public hasInlines(key: string): boolean {
             const node = this.assertNode(key);
             return !!(
-                node.nodes && node.nodes.find(n => n.isInline || n.isText)
+                node.nodes && node.nodes.find(n => n.isInline() || n.isText())
             );
         }
 


### PR DESCRIPTION
I'm opening this PR with some work experiment I've started last weekend.

The goal of those changes was to remove the core schema, and replace it with validations on the node methods.

### `Container` model

It also introduce a new model `Container`, basically a node that can only contain other contains or blocks. It doesn't prevent *yet* the use of blocks to contain other blocks.
This new model is needed because otherwise when creating an empty block, it's impossible to know if we should allow inlines or blocks in it (the core schema rule currently work by testing the nodes already present in the node).

### `node.validateChild(child): boolean`

This PR introduces a method `validateChild` on each node models, this method will be used in manipulation methods to ensure that the operation is possible.

## Potential issues

The potential issues coming from doing those core checks in the models mostly come from the fact that intermediate "invalid" states will no longer be possible in changes.